### PR TITLE
Fix "Platform Game" Link

### DIFF
--- a/lesson_35.md
+++ b/lesson_35.md
@@ -11,7 +11,7 @@ Students will be able to...
 ## Materials/Preparation
 
 -   Reference to the Platform Game Project: [Easy Platform Game](project_3_platform_game_easy.md) ([Download in Word](https://tealsk12.gitbooks.io/introduction-to-computer-science/content/Projects/Projects%20Word/Project%203%20Platform%20Game%20Easy.docx)) ([Link to PDF](https://tealsk12.gitbooks.io/introduction-to-computer-science/content/Projects/Projects%20PDF/Project%203%20Platform%20Game%20Easy.pdf))
--   (Optional) Advanced Version of the project: [Platform Game](project_2.md) ([Download in Word](https://tealsk12.gitbooks.io/introduction-to-computer-science/content/Projects/Projects%20Word/Project%203%20Platform%20Game.docx)) ([Link to PDF](https://tealsk12.gitbooks.io/introduction-to-computer-science/content/Projects/Projects%20PDF/Project%203%20Platform%20Game.pdf))
+-   (Optional) Advanced Version of the project: [Platform Game](project_3.md) ([Download in Word](https://tealsk12.gitbooks.io/introduction-to-computer-science/content/Projects/Projects%20Word/Project%203%20Platform%20Game.docx)) ([Link to PDF](https://tealsk12.gitbooks.io/introduction-to-computer-science/content/Projects/Projects%20PDF/Project%203%20Platform%20Game.pdf))
 
 -   (Optional) Printouts of the specification
 -   A few suggested themes available for students who may struggle to come up with their own.


### PR DESCRIPTION
Currently, the "Platform Game" link points to project 2 (Pong). Update to point to Project 3.