### PR TITLE
Update do_now_22.md

### DIFF
--- a/do_now_22.md
+++ b/do_now_22.md
@@ -1,7 +1,7 @@
-## Do Now 2.2 Zig Zag
+## Do Now 2.2 Zigzag
 
 Follow the link to a [DoNow22](http://snap.berkeley.edu/snapsource/snap.html#present:Username=kenneychan&ProjectName=DoNow22) puzzle.
 
-Reassemble the blocks so Alonzo asks how many zig zags to draw. Then have Alanzo draw zig zags from the center of the stage to the upper right the number of times specfied:
+Reassemble the blocks so Alonzo asks how many zigzags to draw. Then have Alonzo draw zigzags from the center of the stage to the upper right the number of times specfied:
 
-![Zig zag](do_now_22.PNG)
+![Alonzo drawing zigzags](do_now_22.PNG)


### PR DESCRIPTION
Changed "zig zag" to "zigzag", which looks like [the correct spelling](https://www.merriam-webster.com/dictionary/zigzag).

Fixed spelling of Alonzo. Was Alanzo in one location.

Made alt tag more descriptive while I'm in here.