### PR TITLE
Fixing pdf links, fixing duplicate doc title

### DIFF
--- a/docs/lesson_11.md.html
+++ b/docs/lesson_11.md.html
@@ -19,8 +19,8 @@ Students will be able to...
 
 * [1.1 Slide Deck](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/slidedecks/TEALS%20SNAP%201.1.pptx)
 * [Unit 1 Do Now](do_now_11.md.html)
-* [Lab 1.1 handout Welcome to Snap!](lab_11.md.html) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.1%20Welcome%20To%20SNAP.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Lab%201.1%20Welcome%20To%20SNAP.pdf))
-* Helping Trios handout Helping Trios handout [(docx)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf)
+* [Lab 1.1 handout Welcome to Snap!](lab_11.md.html) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.1%20Welcome%20To%20SNAP.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Lab%201.1%20Welcome%20To%20SNAP.pdf))
+* Helping Trios handout Helping Trios handout [(docx)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf)
 * Read through the lab so that you are familiar with the requirements and can assist students as needed
 * [Unit 1 Tips](unit_1_tips.md.html)
 * Video Resource - [https://www.youtube.com/watch?v=b-EWj7xN90U](https://www.youtube.com/watch?v=b-EWj7xN90U)
@@ -122,7 +122,7 @@ Zoom Blocks are a useful tool to increase the readability of code in Snap!. To a
 ## Accommodations/Differentiation
 
 * For students that finish the lab early, encourage them to add more advanced features to their Kaleidoscope program, exploring parts of Snap! not covered in the lab.
-* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity.  You can also use [Helping Trios.](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf)
+* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity.  You can also use [Helping Trios.](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf)
 * No parts of this lab can be easily skipped without impacting learning objectives, so provide as much support or scaffolding as you can to ensure all students can complete the lab.  Add days to the lesson if needed.
 
 ## Forum discussion

--- a/docs/lesson_12.md.html
+++ b/docs/lesson_12.md.html
@@ -19,8 +19,8 @@ Students will be able to...
 
 * [1.2 Slide Deck](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/slidedecks/TEALS%20SNAP%201.2.pptx)
 * [Do Now 1.2: Tracing and Debugging](do_now_12.md.html) If you like you can place a picture of [Admiral Grace Hopper](https://upload.wikimedia.org/wikipedia/commons/2/21/Grace_Murray_Hopper%2C_in_her_office_in_Washington_DC%2C_1978%2C_%C2%A9Lynn_Gilbert.jpg) or her Mark II [notes](https://upload.wikimedia.org/wikipedia/commons/8/8a/H96566k.jpg) that show the bug she found in the computer.
-* [Lab 1.2 handout Snap! Scavenger Hunt](lab_12.md.html) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.2%20SNAP%20Scavenger%20Hunt.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Lab%201.2%20SNAP%20Scavenger%20Hunt.pdf)).
-* Helping Trios handout ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx)) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf).
+* [Lab 1.2 handout Snap! Scavenger Hunt](lab_12.md.html) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.2%20SNAP%20Scavenger%20Hunt.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Lab%201.2%20SNAP%20Scavenger%20Hunt.pdf)).
+* Helping Trios handout ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx)) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf).
 * Read through the handout so that you are familiar with the requirements and can assist students.
 * Index cards with each students name on them. One name per index card.
 * [Unit 1 Tips](unit_1_tips.md.html).
@@ -87,7 +87,7 @@ Students will be able to...
 ## Accommodations/Differentiation
 
 * Colorblind students may not be able to identify the block colors, but can still recognize the organization of categories. Be sensitive to this, but no modifications are likely required.
-* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity. Use you could also use [Helping Trios](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf).
+* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity. Use you could also use [Helping Trios](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf).
 * The bonus assignment (3.4) should be used for students who finish quickly, and can be a setup for the [Animation Project](project_1.md.html).
 
 ## Forum discussion

--- a/docs/lesson_14.md.html
+++ b/docs/lesson_14.md.html
@@ -18,7 +18,7 @@ Students will be able to...
 
 * [Do Now 1.4: Sprite Communication](do_now_14.md.html).
 * [1.4 Slide Deck](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/slidedecks/TEALS%20SNAP%201.4.pptx)
-* [Lab 1.4 handout (Sprites in Action)](lab_14.md.html)([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.4%20Sprites%20in%20Action.docx)) ([blocks](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Lab%201.4%20Sprites%20in%20Action.pdf)).
+* [Lab 1.4 handout (Sprites in Action)](lab_14.md.html)([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.4%20Sprites%20in%20Action.docx)) ([blocks](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Lab%201.4%20Sprites%20in%20Action.pdf)).
 * [Unit 1 Tips](unit_1_tips.md.html).
 * Video Resource: [https://youtu.be/3x5ZI-mKc44](https://youtu.be/3x5ZI-mKc44)
   * Video Quiz: See Additional Curriculum Materials accessed from the TEALS Dashboard.

--- a/lesson_11.md
+++ b/lesson_11.md
@@ -12,8 +12,8 @@ Students will be able to...
 
 * [1.1 Slide Deck](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/slidedecks/TEALS%20SNAP%201.1.pptx)
 * [Unit 1 Do Now](do_now_11.md)
-* [Lab 1.1 handout Welcome to Snap!](lab_11.md) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.1%20Welcome%20To%20SNAP.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Lab%201.1%20Welcome%20To%20SNAP.pdf))
-* Helping Trios handout Helping Trios handout [(docx)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf)
+* [Lab 1.1 handout Welcome to Snap!](lab_11.md) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.1%20Welcome%20To%20SNAP.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Lab%201.1%20Welcome%20To%20SNAP.pdf))
+* Helping Trios handout [(docx)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf)
 * Read through the lab so that you are familiar with the requirements and can assist students as needed
 * [Unit 1 Tips](unit_1_tips.md)
 * Video Resource - [https://www.youtube.com/watch?v=b-EWj7xN90U](https://www.youtube.com/watch?v=b-EWj7xN90U)
@@ -115,7 +115,7 @@ Zoom Blocks are a useful tool to increase the readability of code in Snap!. To a
 ## Accommodations/Differentiation
 
 * For students that finish the lab early, encourage them to add more advanced features to their Kaleidoscope program, exploring parts of Snap! not covered in the lab.
-* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity.  You can also use [Helping Trios.](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf)
+* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity.  You can also use [Helping Trios.](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf)
 * No parts of this lab can be easily skipped without impacting learning objectives, so provide as much support or scaffolding as you can to ensure all students can complete the lab.  Add days to the lesson if needed.
 
 ## Forum discussion

--- a/lesson_12.md
+++ b/lesson_12.md
@@ -12,8 +12,8 @@ Students will be able to...
 
 * [1.2 Slide Deck](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/slidedecks/TEALS%20SNAP%201.2.pptx)
 * [Do Now 1.2: Tracing and Debugging](do_now_12.md) If you like you can place a picture of [Admiral Grace Hopper](https://upload.wikimedia.org/wikipedia/commons/2/21/Grace_Murray_Hopper%2C_in_her_office_in_Washington_DC%2C_1978%2C_%C2%A9Lynn_Gilbert.jpg) or her Mark II [notes](https://upload.wikimedia.org/wikipedia/commons/8/8a/H96566k.jpg) that show the bug she found in the computer.
-* [Lab 1.2 handout Snap! Scavenger Hunt](lab_12.md) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.2%20SNAP%20Scavenger%20Hunt.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Lab%201.2%20SNAP%20Scavenger%20Hunt.pdf)).
-* Helping Trios handout ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx)) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf).
+* [Lab 1.2 handout Snap! Scavenger Hunt](lab_12.md) ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.2%20SNAP%20Scavenger%20Hunt.docx)) ([pdf](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Lab%201.2%20SNAP%20Scavenger%20Hunt.pdf)).
+* Helping Trios handout ([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Helping%20Trios.docx)) [(pdf)](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf).
 * Read through the handout so that you are familiar with the requirements and can assist students.
 * Index cards with each students name on them. One name per index card.
 * [Unit 1 Tips](unit_1_tips.md).
@@ -80,7 +80,7 @@ Students will be able to...
 ## Accommodations/Differentiation
 
 * Colorblind students may not be able to identify the block colors, but can still recognize the organization of categories. Be sensitive to this, but no modifications are likely required.
-* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity. Use you could also use [Helping Trios](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Helping%20Trios.pdf).
+* Students that are struggling with the lab can be paired up and/or receive individual instructor attention to help them through the activity. Use you could also use [Helping Trios](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Helping%20Trios.pdf).
 * The bonus assignment (3.4) should be used for students who finish quickly, and can be a setup for the [Animation Project](project_1.md).
 
 ## Forum discussion

--- a/lesson_14.md
+++ b/lesson_14.md
@@ -11,7 +11,7 @@ Students will be able to...
 
 * [Do Now 1.4: Sprite Communication](do_now_14.md).
 * [1.4 Slide Deck](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/slidedecks/TEALS%20SNAP%201.4.pptx)
-* [Lab 1.4 handout (Sprites in Action)](lab_14.md)([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.4%20Sprites%20in%20Action.docx)) ([blocks](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20pdf/Lab%201.4%20Sprites%20in%20Action.pdf)).
+* [Lab 1.4 handout (Sprites in Action)](lab_14.md)([docx](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20Word/Lab%201.4%20Sprites%20in%20Action.docx)) ([blocks](https://github.com/TEALSK12/introduction-to-computer-science/raw/master/Unit%201%20PDF/Lab%201.4%20Sprites%20in%20Action.pdf)).
 * [Unit 1 Tips](unit_1_tips.md).
 * Video Resource: [https://youtu.be/3x5ZI-mKc44](https://youtu.be/3x5ZI-mKc44)
   * Video Quiz: See Additional Curriculum Materials accessed from the TEALS Dashboard.


### PR DESCRIPTION
Just updating the links on the site to use capitalized "PDF" in the path name.
Also deleted a duplicate "Helping Trios handout".