### PR TITLE
Replace broken Hour of Code challenges

### DIFF
--- a/lesson_03.md
+++ b/lesson_03.md
@@ -14,9 +14,9 @@ Students will be able to...
 * **IMPORTANT: At least a few days prior to class,** ensure that the classroom computers can load the website for both activities.  If not, work with school IT to solve the problem.
   * If you are not able to load Snap! on your classroom computers, you will not be able to proceed with the course.  Test this well ahead of time and make sure your school's IT staff knows what the requirements are and can help achieve them.
 * Work through at least one of the coding activities on your own so you are familiar with the activities and can provide assistance as needed:
-  * [LightBot Hour of Code](http://lightbot.com/hour-of-code.html) (the online version requires flash)
   * [Minecraft Adventurer (Code.org)](https://studio.code.org/s/mc/stage/1/puzzle/1)
-  * [Snap!Hour of Code](https://bjc.edc.org/hourofcode/#1)
+  * [Dance Party (Code.org)](https://studio.code.org/s/dance-2019/lessons/1/levels/1)
+  * [Choose your own](https://hourofcode.com/us/learn)
 * Part 3 of the LightBot activity calls itself "Loops" but is really using recursion (specifically tail-recursion). The exercises are still valuable, but be prepared to potentially discuss, or at least point out, the distinction so students are not confused when they encounter normal loops later.
 * [Unit 0 Tips](unit_0_tips.md)
 * Video Resource: [https://www.youtube.com/watch?v=6qF3HmRzg8o](https://www.youtube.com/watch?v=6qF3HmRzg8o)


### PR DESCRIPTION
Lesson 0.3 recommends picking from the following activities:

[LightBot Hour of Code](https://lightbot.com/hour-of-code.html)
[Minecraft Adventurer (Code.org)](https://studio.code.org/s/mc/lessons/1/levels/1)
[Snap!Hour of Code](https://bjc.edc.org/hourofcode/#1)

LightBot requires flash, which is End-Of-Life and [Adobe recommends uninstalling it](https://www.adobe.com/products/flashplayer/end-of-life.html).
Minecraft Adventurer works fine, but it's not using Snap. 
Snap!Hour of Code is buggy. The layout is broken and it crashes. 

Between these three options, Minecraft Adventurer is the only one I'd recommend. I suggest removing the Snap! and LightBot options. I replaced them with some other options I found on hourofcode.com.