### PR TITLE
fix incorrect instruction in lab 4.2

### DIFF
--- a/lab_42.md
+++ b/lab_42.md
@@ -20,6 +20,11 @@ In this lab, you will create a simple sentence generator using lists.
 1. Write a custom reporter block called “noun phrase” that reports a noun phrase where each word is chosen randomly from the lists you created.
 
     ```A noun phrase consists of an article, an adjective, and a noun in that order.```
+    
+    Using our sample lists of words from part 1, here are a few examples of possible outputs from the "noun phrase" block:
+    * a silly elephant
+    * the sleepy boy
+    * the sleepy giraffe
 
 2. Write custom reporter blocks like “noun phrase” for each of the phrase types listed below.
 
@@ -28,15 +33,19 @@ In this lab, you will create a simple sentence generator using lists.
 |noun phrase (completed in step 1) | article, adjective, noun]
 |prepositional phrase  | preposition, noun phrase|
 |verb phrase|adverb, verb, prepositional phrase|
-|sentence|noun, phrase, verb phrase|
+|sentence|noun phrase, verb phrase|
+
+Using our sample lists of words from part 1, here are some possible outputs from each block:
+* **noun phrase**: a small monkey
+* **prepositional phrase**: around a sleepy elephant
+* **verb phrase**: sadly dances beside the young boy
+* **sentence**: the old giraffe quickly jumps over a silly elephant
 
 ## Part 3: Making sentences
 
 1. Modify your script so that when you press the space bar, a random sentence is generated and a sprite says the resulting sentence.
 
-Bonus: Modify your script so that a noun phrase can either be the construction from part 1 or a single proper noun (e.g. a person's name).  Your script should randomly decide which version of a noun phrase to use.
-
-    _A noun phrase consists of an article, an adjective, and a noun in that order._
+Bonus: Modify your script so that a noun phrase can either be the construction from part 1 or a single proper noun (e.g. a person's name).  Each time your noun phrase block is used, it should randomly choose which kind of noun phrase to report. *Note: you'll need a new list to store some proper nouns.*
 
 Bonus: Modify your script so that a verb phrase can sometimes leave out the prepositional phrase.  Your script should randomly decide to include the prepositional phrase or not.
 
@@ -48,6 +57,7 @@ Bonus: Modify your script so that a verb phrase can sometimes leave out the prep
 
     | Key | Part of speech |
     | --- | -------------- |
+    | n   | noun           |
     | v   | verb           |
     | j   | adjective      |
     | d   | adverb         |

--- a/lab_42.md
+++ b/lab_42.md
@@ -25,8 +25,9 @@ In this lab, you will create a simple sentence generator using lists.
 
 | Phrase type | Construction |
 |--|--|
+|noun phrase (completed in step 1) | article, adjective, noun]
 |prepositional phrase  | preposition, noun phrase|
-|verb phrase|adverb, prpositional phrase|
+|verb phrase|adverb, verb, prepositional phrase|
 |sentence|noun, phrase, verb phrase|
 
 ## Part 3: Making sentences


### PR DESCRIPTION
The definition of a verb phrase was incorrect and included a typo. Also added Noun Phrase to the table for clarity.